### PR TITLE
refactor: use Fs.FileRead instead of deprecated FileRead

### DIFF
--- a/src/Talpin/RunFile.flix
+++ b/src/Talpin/RunFile.flix
@@ -4,9 +4,7 @@ mod Talpin.RunFile {
     use Talpin.EffectSolver
     use Talpin.Data.Subst
     use Sys.Env
-    use Util.Util
-
-    pub def checkFileArg(): Result[RichString, Unit] \ IO =
+    pub def checkFileArg(): Result[RichString, Unit] \ IO + Fs.FileRead =
         run {
             match Env.getArgs() {
                 case path :: Nil => checkFile(path)
@@ -14,37 +12,30 @@ mod Talpin.RunFile {
             }
         }
         with Env.runWithIO
-        with Util.fileReadRunWithAbort
         with Abort.runWithResult
 
-    pub def checkFile(path: String): Unit \ IO =
+    pub def checkFile(path: String): Unit \ IO + Fs.FileRead =
         run checkFileEff(path)
-        with Util.fileReadRunWithAbort
         with handler Abort {
             def abort(m, _k) = println(m)
         }
 
-    pub def checkFileEff(path: String): Unit \ IO + Abort + FileRead = {
-        if (FileRead.isReadable(path)) {
-            let input = FileRead.read(path);
-            let p =
-                run Talpin.Parsing.Parser.parse(input)
-                with handler Abort {
-                    def abort(m, _k) = Abort.abort(Formattable.format("Parsing Error: ${m}"))
-                };
-            let info =
-                run Reconstruction.reconstructInfo(p)
-                with FreshName.runWithState
-                with handler Abort {
-                    def abort(m, _k) = Abort.abort(Formattable.format("Typer Error: ${m}"))
-                } with handler KeyNotFound {
-                    def keyNotFound(msg, _k) = Abort.abort(Formattable.format("Typer Error: ${msg}"))
-                };
-            info |> Reconstruction.Info.toStrings |> List.forEach(println)
-
-        } else {
-            println("cannot find ${path}")
-        }
+    pub def checkFileEff(path: String): Unit \ IO + Abort + Fs.FileRead = {
+        let input = Fs.FileRead.read(path) |> Result.getOrAbort;
+        let p =
+            run Talpin.Parsing.Parser.parse(input)
+            with handler Abort {
+                def abort(m, _k) = Abort.abort(Formattable.format("Parsing Error: ${m}"))
+            };
+        let info =
+            run Reconstruction.reconstructInfo(p)
+            with FreshName.runWithState
+            with handler Abort {
+                def abort(m, _k) = Abort.abort(Formattable.format("Typer Error: ${m}"))
+            } with handler KeyNotFound {
+                def keyNotFound(msg, _k) = Abort.abort(Formattable.format("Typer Error: ${msg}"))
+            };
+        info |> Reconstruction.Info.toStrings |> List.forEach(println)
     }
 
 }

--- a/src/Util/Util.flix
+++ b/src/Util/Util.flix
@@ -29,9 +29,4 @@ mod Util.Util {
         loop(n, Nil)
     }
 
-    pub def fileReadRunWithAbort(f: Unit -> b \ ef): b \ ef - FileRead + {Abort, IO} =
-        match FileRead.runWithIO(f) {
-            case Ok(v) => v
-            case Err(_ioError) => Abort.abort(Formattable.format("IoError"))
-        }
 }


### PR DESCRIPTION
Replace deprecated FileRead effect with Fs.FileRead which returns Result types. Use Result.getOrAbort to unwrap file read results. Remove fileReadRunWithAbort utility which is no longer needed.